### PR TITLE
fix: add missing shebang

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { execSync } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { argv, chdir } from "node:process";


### PR DESCRIPTION
After taking a look at the create-t3-app codebase, it seems they have this shebang on the beginning of their entrypoint file.

This should fix this problem:
![image](https://github.com/NicolasLopes7/nicolas/assets/50559336/364885f3-8e42-422d-8e88-01a80932a4ce)
