### PR TITLE
feat: add git ignore in template

### DIFF
--- a/src/addons/lint.ts
+++ b/src/addons/lint.ts
@@ -83,6 +83,26 @@ export const addLint = async (packageManager: "pnpm" | "yarn" | "npm") => {
     
     module.exports = config;`;
 
+    const gitignoreConfigContent =  `
+    node_modules
+    .log
+   
+    # local env files
+    .env.local
+    .env
+
+    # testing
+    /coverage
+
+    # production
+    dist
+
+    # misc
+    .DS_Store
+    *.pem
+    `
+
+  await writeFile('.gitignore', gitignoreConfigContent)
   await writeFile("prettier.config.mjs", prettierConfigContent);
   await writeFile(".eslintrc.cjs", eslintConfigContent);
 };


### PR DESCRIPTION
I used your template last week but I missed the gitignore, so I added : )

the content I used and think it addresses most of the uses was

   ```
const gitignoreConfigContent =  
    node_modules
    .log
   
    # local env files
    .env.local
    .env

    # testing
    /coverage

    # production
    dist

    # misc
    .DS_Store
    *.pem
